### PR TITLE
Indefinite Duration Support + Saves fixes

### DIFF
--- a/Message.txt
+++ b/Message.txt
@@ -58,7 +58,7 @@ Class notHudMessage : HUDMessageBase
 
 	virtual bool DoTick()
 	{
-		if (holdtics == -Thinker.TICRATE)
+		if (holdtics < 0)
 		{
 			if (tics < intics)	
 				alpha = Min(1.0, (1.0 / intics) * tics);

--- a/Message.txt
+++ b/Message.txt
@@ -8,7 +8,8 @@
 Class notHudMessage : HUDMessageBase
 {
 	transient BrokenLines lines;
-	HUDFont fnt;
+	transient Font rFont;
+	Name fnt;
 	double alpha;
 	int wrap, talign, tics, holdtics, intics, outtics, color, layer;
 	Vector2 balign, pos, vsize, bsize;
@@ -32,7 +33,7 @@ Class notHudMessage : HUDMessageBase
 	{
 		double vw = (vsize.x>0)?vsize.x:Screen.GetWidth();
 		double vh = (vsize.y>0)?vsize.y:Screen.GetHeight();
-		Screen.DrawText(fnt.mFont,color,x,y,line,DTA_VirtualWidthF,vw,DTA_VirtualHeightF,vh,DTA_Alpha,alpha);
+		Screen.DrawText(rFont,color,x,y,line,DTA_VirtualWidthF,vw,DTA_VirtualHeightF,vh,DTA_Alpha,alpha);
 	}
 
 	override void Draw( int bottom, int visibility )
@@ -45,18 +46,30 @@ Class notHudMessage : HUDMessageBase
 		for ( int i=0; i<lines.Count(); i++ )
 		{
 			line = lines.StringAt(i);
-			len = fnt.mFont.StringWidth(line);
+			len = rFont.StringWidth(line);
 			// calculate text alignment
 			if ( talign < 0 ) linex = base.x;
 			else if ( talign > 0 ) linex = base.x+(bsize.x-len);
 			else linex = base.x+(bsize.x-len)/2.0;
 			DrawLine(linex,liney,line);
-			liney += fnt.mFont.GetHeight();
+			liney += rFont.GetHeight();
 		}
 	}
 
 	virtual bool DoTick()
 	{
+		if (holdtics == -Thinker.TICRATE)
+		{
+			if (tics < intics)	
+				alpha = Min(1.0, (1.0 / intics) * tics);
+			else
+			{
+				alpha = 1.0;
+				tics = intics;
+			}
+			return false;
+		}
+	
 		uint total = holdtics + intics + outtics;
 		if (total && (tics > total)) return true;	// Message expired.
 		int inhold = holdtics + intics;
@@ -79,14 +92,15 @@ Class notHudMessage : HUDMessageBase
 
 	virtual void Setup()
 	{
-		lines = fnt.mFont.BreakLines(txt,(wrap<=0)?int.max:wrap);
+		rFont = Font.GetFont(fnt);
+		lines = rFont.BreakLines(txt,(wrap<=0)?int.max:wrap);
 		double longest = 0, len;
 		for ( int i=0; i<lines.Count(); i++ )
 		{
-			len = fnt.mFont.StringWidth(lines.StringAt(i));
+			len = rFont.StringWidth(lines.StringAt(i));
 			if ( len > longest ) longest = len;
 		}
-		bsize = (longest,fnt.mFont.GetHeight()*lines.Count());
+		bsize = (longest,rFont.GetHeight()*lines.Count());
 	}
 
 	void Init()
@@ -94,7 +108,7 @@ Class notHudMessage : HUDMessageBase
 		tics = 0;
 	}
 
-	static clearscope QueuedMsg Create( Font fnt, string txt, Vector2 pos, Vector2 vsize = (0,0), int talign = -1, Vector2 balign = (0,0), int color = Font.CR_UNTRANSLATED, Vector3 time = (0,0,0), int wrap = 0, uint id = 0, int layer = BaseStatusBar.HUDMSGLayer_OverHUD )
+	static clearscope QueuedMsg Create( Name fnt, string txt, Vector2 pos, Vector2 vsize = (0,0), int talign = -1, Vector2 balign = (0,0), int color = Font.CR_UNTRANSLATED, Vector3 time = (0,0,0), int wrap = 0, uint id = 0, int layer = BaseStatusBar.HUDMSGLayer_OverHUD )
 	{
 		let msg = new("QueuedMsg");
 		msg.fnt = fnt;
@@ -126,8 +140,8 @@ Class notHudMessageWaggle : notHudMessage
 		double cphase = phase;
 		for ( int i=0; i<line.length(); i++ )
 		{
-			Screen.DrawChar(fnt.mFont,color,x,y+sin(cphase)*strength,line.CharCodeAt(i),DTA_VirtualWidthF,vw,DTA_VirtualHeightF,vh,DTA_Alpha,alpha);
-			x += fnt.mFont.GetCharWidth(line.CharCodeAt(i));
+			Screen.DrawChar(rFont,color,x,y+sin(cphase)*strength,line.CharCodeAt(i),DTA_VirtualWidthF,vw,DTA_VirtualHeightF,vh,DTA_Alpha,alpha);
+			x += rFont.GetCharWidth(line.CharCodeAt(i));
 			cphase += frequency;
 		}
 	}
@@ -144,7 +158,7 @@ Class notHudMessageWaggle : notHudMessage
 		phase = 0;
 	}
 
-	static clearscope QueuedMsgWaggle Create( Font fnt, string txt, Vector2 pos, Vector2 vsize = (0,0), int talign = -1, Vector2 balign = (0,0), int color = Font.CR_UNTRANSLATED, Vector3 time = (0,0,0), double speed = 1.0, double strength = 1.0, double frequency = 1.0, int wrap = 0, uint id = 0, int layer = BaseStatusBar.HUDMSGLayer_OverHUD )
+	static clearscope QueuedMsgWaggle Create( Name fnt, string txt, Vector2 pos, Vector2 vsize = (0,0), int talign = -1, Vector2 balign = (0,0), int color = Font.CR_UNTRANSLATED, Vector3 time = (0,0,0), double speed = 1.0, double strength = 1.0, double frequency = 1.0, int wrap = 0, uint id = 0, int layer = BaseStatusBar.HUDMSGLayer_OverHUD )
 	{
 		let msg = new("QueuedMsgWaggle");
 		msg.fnt = fnt;
@@ -170,7 +184,7 @@ Class notHudMessageWaggle : notHudMessage
 
 Class QueuedMsg
 {
-	Font fnt;
+	Name fnt;
 	TextureID tex;
 	string txt;
 	Vector2 pos, vsize, balign;
@@ -182,7 +196,7 @@ Class QueuedMsg
 	virtual ui void AddSelf()
 	{
 		let msg = new("notHudMessage");
-		msg.fnt = HUDFont.Create(fnt);
+		msg.fnt = fnt;
 		msg.txt = txt;
 		msg.pos = pos;
 		msg.vsize = vsize;
@@ -206,7 +220,7 @@ Class QueuedMsgWaggle : QueuedMsg
 	override void AddSelf()
 	{
 		let msg = new("notHudMessageWaggle");
-		msg.fnt = HUDFont.Create(fnt);
+		msg.fnt = fnt;
 		msg.txt = txt;
 		msg.pos = pos;
 		msg.vsize = vsize;
@@ -261,22 +275,31 @@ Class notHudMessageHandler : EventHandler
 	// test functions
 	override void NetworkProcess( ConsoleEvent e )
 	{
-		if ( e.Name ~== "TestMsg" )
+		if ( e.Name == 'TestMsg' )
 		{
 			Vector2 midscr = (Screen.GetWidth(),Screen.GetHeight())*0.5;
-			WaggleMsg(smallfont,"How did this get here I am not good with computer",(160,180),(320,200),time:(1,3,1), frequency:60.0);
-			PlainMsg(Font.GetFont('STFOUCH0'),"A A A",(80,50),(160,100),time:(1,3,1));
+			WaggleMsg('smallfont',"How did this get here I am not good with computer",(160,180),(320,200),time:(1,3,1), frequency:60.0);
+			PlainMsg('STFOUCH0',"A A A",(80,50),(160,100),time:(1,3,1));
 		}
 	}
-
-	static void PlainMsg( Font fnt, string txt, Vector2 pos, Vector2 vsize = (0,0), int talign = -1, Vector2 balign = (0,0), int color = Font.CR_UNTRANSLATED, Vector3 time = (0,0,0), int wrap = 0, uint id = 0, int layer = BaseStatusBar.HUDMSGLayer_OverHUD )
+	
+	static bool CheckFont( Name fnt )
 	{
+		Font f = Font.GetFont(fnt);
+		if (!f)	Console.Printf("%s is not a font!", fnt);
+		return (f != null);
+	}
+
+	static void PlainMsg( Name fnt, string txt, Vector2 pos, Vector2 vsize = (0,0), int talign = -1, Vector2 balign = (0,0), int color = Font.CR_UNTRANSLATED, Vector3 time = (0,0,0), int wrap = 0, uint id = 0, int layer = BaseStatusBar.HUDMSGLayer_OverHUD )
+	{
+		if (!notHudMessageHandler.CheckFont(fnt))	return;
 		QueuedMsg tosend = notHudMessage.Create(fnt,txt,pos,vsize,talign,balign,color,time,wrap,id,layer);
 		QueueMsg(tosend);
 	}
 
-	static void WaggleMsg( Font fnt, string txt, Vector2 pos, Vector2 vsize = (0,0), int talign = -1, Vector2 balign = (0,0), int color = Font.CR_UNTRANSLATED, Vector3 time = (0,0,0), double speed = 1.0, double strength = 1.0, double frequency = 1.0, int wrap = 0, uint id = 0, int layer = BaseStatusBar.HUDMSGLayer_OverHUD )
+	static void WaggleMsg( Name fnt, string txt, Vector2 pos, Vector2 vsize = (0,0), int talign = -1, Vector2 balign = (0,0), int color = Font.CR_UNTRANSLATED, Vector3 time = (0,0,0), double speed = 1.0, double strength = 1.0, double frequency = 1.0, int wrap = 0, uint id = 0, int layer = BaseStatusBar.HUDMSGLayer_OverHUD )
 	{
+		if (!notHudMessageHandler.CheckFont(fnt))	return;
 		QueuedMsg tosend = notHudMessageWaggle.Create(fnt,txt,pos,vsize,talign,balign,color,time,speed,strength,frequency,wrap,id,layer);
 		QueueMsg(tosend);
 	}


### PR DESCRIPTION
Added support for <= -1 (forever) hold duration. This includes fading in before holding indefinitely.

- Pass in names instead of fonts through functions. Names are serializable and Font.GetFont can accept names.
- Replaced HUDFont with regular Font instead. HUDFont is apparently an abstract class that causes saves to immediately abort when loading.
- Added a safety check for PlainMsg and WaggleMsg which prints if the font cannot be found, and will abort attempting to make a message.